### PR TITLE
use ruff instead of flake8

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -1,0 +1,14 @@
+name: Auto-update Charm Libraries
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Check regularly the upstream every four hours
+  schedule:
+    - cron: "0 0,4,8,12,16,20 * * *"
+
+jobs:
+  update-lib:
+    name: Check libraries
+    uses: canonical/observability/.github/workflows/update-libs.yaml@main
+    secrets: inherit
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @sed-i @abuelodelanada @rbarry82 @lucabello @pietropasotti @dstathis @simskij

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Karma Alertmanager Proxy (k8s)
 
+[![CharmHub Badge](https://charmhub.io/karma-alertmanager-proxy-k8s/badge.svg)](https://charmhub.io/karma-alertmanager-proxy-k8s)
+[![Release to Edge](https://github.com/canonical/karma-alertmanager-proxy-k8s-operator/actions/workflows/release-edge.yaml/badge.svg)](https://github.com/canonical/karma-alertmanager-proxy-k8s-operator/actions/workflows/release-edge.yaml)
+[![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
+
 ## Description
 
 Proxy charm to provide the details of an [Alertmanager][Alertmanager operator]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,26 +13,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,10 +4,9 @@
 
 import unittest
 
+from charm import KarmaAlertmanagerProxyCharm
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
-
-from charm import KarmaAlertmanagerProxyCharm
 
 
 class TestCharm(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -30,29 +30,20 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static]

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
-[testenv:static]
+[testenv:static-charm]
 description = Run static analysis checks
 deps =
     -r{toxinidir}/requirements.txt
@@ -63,7 +63,7 @@ deps =
 commands =
     pip-missing-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
     pip-extra-reqs {toxinidir}/src {toxinidir}/lib --requirements-file={toxinidir}/requirements.txt
-    mypy {[vars]all_path} {posargs}
+    mypy {[vars]src_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being one new rule being ignored (which weren't checked before anyway): 
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.

---

Drive-by additions:
* `README.md` and `CODEOWNERS` update;
* `update-libs.yaml` CI