### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+  schedule:
+    - cron: "00 23 * * *"
 
 permissions:
   security-events:
@@ -36,18 +38,18 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -61,4 +63,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,20 @@
+name: Promote Charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      promotion:
+        type: choice
+        description: Channel to promote from
+        options:
+          - edge -> beta
+          - beta -> candidate
+          - candidate -> stable
+
+jobs:
+  promote:
+    name: Promote
+    uses: canonical/observability/.github/workflows/promote-charm.yaml@main
+    with:
+      promotion: ${{ github.event.inputs.promotion }}
+    secrets: inherit

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,74 +1,12 @@
-name: Pull Request
+name: Pull Requests
+
 on:
   pull_request:
     branches:
       - main
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.1-rc
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  static-charm:
-    name: Static analysis of the charm and tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run static analysis
-        run: tox -vve static
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run linters
-        run: tox -vve lint
-
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python -m pip install tox
-      - name: Run tests
-        run: tox -vve unit
-
-  integration-test:
-    name: Integration tests (microk8s)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-      - name: Run tests
-        run: tox -vve integration
+  pull-request:
+    name: PR
+    uses: canonical/observability/.github/workflows/pull-request.yaml@main
+    secrets: inherit

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -1,98 +1,11 @@
 name: Release to Edge
+
 on:
   push:
     branches:
       - main
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.1-rc
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  static-charm:
-    name: Static analysis of the charm and tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run static analysis
-        run: tox -vve static
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run linters
-        run: tox -vve lint
-
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python -m pip install tox
-      - name: Run tests
-        run: tox -vve unit
-
-  integration-test:
-    name: Integration tests (microk8s)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-      - name: Run tests
-        run: tox -vve integration
-
-  release-to-charmhub:
-    name: Release to CharmHub
-    needs:
-      - lib-check
-      - static-charm
-      - lint
-      - unit-test
-      - integration-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@1.0.1-rc
-        id: channel
-      - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@1.0.1-rc
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+  release:
+    uses: canonical/observability/.github/workflows/release-charm.yaml@main
+    secrets: inherit

--- a/tox.ini
+++ b/tox.ini
@@ -80,10 +80,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju~=3.0.0
-    #git+https://github.com/juju/python-libjuju.git
+    juju~=3.1.0
     pytest
     pytest-operator
-    #git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration


### PR DESCRIPTION
## Issue
CI is outdated and release [fails](https://github.com/canonical/karma-alertmanager-proxy-k8s-operator/actions/runs/4885738016): attempts to pack with destructive mode on `ubuntu-latest`, but `build-on` is 20.04.

## Solution
Copy over the reusable workflows.


## Release Notes
Update CI.