### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,12 @@ deps =
 commands =
     pyright {[vars]src_path} {posargs}
 
+
+[testenv:static-lib]
+description = Run static analysis checks
+commands =
+    : # noop; no static lib check needed!
+
 [testenv:reqs]
 description = Check for missing or unused requirements
 deps =


### PR DESCRIPTION
This PR adds a noop environment for static-lib, as that is required by all repos. We don't really need or care about that in this charm, hence this PR.