### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 """Proxy charm for providing alertmanager URL info to Karma."""
 
 import logging
+import typing
 
 from charms.karma_k8s.v0.karma_dashboard import KarmaProvider
 from ops.charm import CharmBase
@@ -44,7 +45,7 @@ class KarmaAlertmanagerProxyCharm(CharmBase):
         if url := self.config.get("url"):
             logger.debug("url = %s", url)
 
-            self.karma_provider.target = url
+            self.karma_provider.target = typing.cast(str, url)
 
         self._update_unit_status()
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run `tox -e static-charm` with / without this change, with ops 2.12 and ops 2.13 (or the PR linked above if before that release).

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A